### PR TITLE
Add nixos support.

### DIFF
--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -86,5 +86,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v17
-      - name: nix check
-        run: nix check
+      - name: nix flake check
+        run: nix flake check

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -78,3 +78,13 @@ jobs:
         with:
           name: coverage
           path: target/llvm-cov/html
+
+  nix:
+    runs-on: ubuntu-latest
+    name: Check Nix Flake
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+      - name: nix check
+        run: nix check

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .zebra-state/
 # Nix configs
 shell.nix
+# Nix build results:
+result
 # Docker compose env files
 *.env
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734961910,
+        "narHash": "sha256-F4iNNs84rdqN2ZDCKtZrE/PUIfUe6YSZM/O2sckeQr4=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "b02b7ca7c98eee7fe26ac18277040c3fc814b52d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1734808813,
+        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1735194898,
+        "narHash": "sha256-JePC5P8YHoLkK7u+0gm0da3rUF3d/N4Qo1q2zvHdVxM=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "cc13ba51f1a3b8eaa4c03fbe46d029effbbcb3c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734988233,
+        "narHash": "sha256-Ucfnxq1rF/GjNP3kTL+uTfgdoE9a3fxDftSfeLIS8mA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "de1864217bfa9b5845f465e771e0ecb48b30e02d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,11 @@
         inherit (pkgs) lib;
 
         # Print out a JSON serialization of the argument as a stderr diagnostic:
-        traceJson = lib.debug.traceValFn builtins.toJSON;
+        enableTrace = false;
+        traceJson =
+          if enableTrace
+          then (lib.debug.traceValFn builtins.toJSON)
+          else (x: x);
 
         craneLib = crane.mkLib pkgs;
 
@@ -184,41 +188,50 @@
           # Note that this is done as a separate derivation so that
           # we can block the CI if there are issues here, but not
           # prevent downstream consumers from building our crate by itself.
-          my-workspace-clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
+
+          # my-workspace-clippy = craneLib.cargoClippy (commonArgs // {
+          #   inherit (zebrad) pname version;
+          #   inherit cargoArtifacts;
+
+          #   cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          # });
 
           my-workspace-doc = craneLib.cargoDoc (commonArgs // {
+            inherit (zebrad) pname version;
             inherit cargoArtifacts;
           });
 
           # Check formatting
           my-workspace-fmt = craneLib.cargoFmt {
+            inherit (zebrad) pname version;
             inherit src;
           };
 
-          my-workspace-toml-fmt = craneLib.taploFmt {
-            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
-            # taplo arguments can be further customized below as needed
-            # taploExtraArgs = "--config ./taplo.toml";
-          };
+          # my-workspace-toml-fmt = craneLib.taploFmt {
+          #   src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
+          #   # taplo arguments can be further customized below as needed
+          #   # taploExtraArgs = "--config ./taplo.toml";
+          # };
 
           # Audit dependencies
           my-workspace-audit = craneLib.cargoAudit {
+            inherit (zebrad) pname version;
             inherit src advisory-db;
           };
 
           # Audit licenses
-          my-workspace-deny = craneLib.cargoDeny {
-            inherit src;
-          };
+          # my-workspace-deny = craneLib.cargoDeny {
+          #   inherit (zebrad) pname version;
+          #   inherit src;
+          # };
 
           # Run tests with cargo-nextest
           # Consider setting `doCheck = false` on other crate derivations
           # if you do not want the tests to run twice
           my-workspace-nextest = craneLib.cargoNextest (commonArgs // {
+            inherit (zebrad) pname version;
             inherit cargoArtifacts;
+
             partitions = 1;
             partitionType = "count";
           });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,210 @@
+# Build, testing, and developments specification for the `nix` environment
+#
+# # Prerequisites
+#
+# - Install the `nix` package manager: https://nixos.org/download/
+# - Configure `flake` support: https://nixos.wiki/wiki/Flakes
+#
+# # Build
+#
+# ```
+# $ nix build --print-build-logs
+# ```
+#
+# This produces:
+#
+# - ./result/bin/zebra-scanner
+# - ./result/bin/zebrad-for-scanner
+# - ./result/bin/zebrad
+#
+# # Development
+#
+# ```
+# $ nix develop
+# ```
+#
+# This starts a new subshell with a development environment, such as
+# `cargo`, `clang`, `protoc`, etc... So `cargo test` for example should
+# work.
+{
+  description = "The zebra zcash node binaries and crates";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane.url = "github:ipetkov/crane";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-analyzer-src.follows = "";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        inherit (pkgs) lib;
+
+        # Print out a JSON serialization of the argument as a stderr diagnostic:
+        traceJson = lib.debug.traceValFn builtins.toJSON;
+
+        craneLib = crane.mkLib pkgs;
+
+        # We use the latest nixpkgs `libclang`:
+        inherit (pkgs.llvmPackages)
+          libclang
+        ;
+
+        src = lib.sources.cleanSource ./.;
+
+        # Common arguments can be set here to avoid repeating them later
+        commonArgs = {
+          inherit src;
+
+          strictDeps = true;
+          # NB: we disable tests since we'll run them all via cargo-nextest
+          doCheck = false;
+
+          # Use the clang stdenv:
+          inherit (pkgs.llvmPackages) stdenv;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            protobuf
+          ];
+
+          buildInputs = with pkgs; [
+            libclang
+            rocksdb
+          ];
+
+          # Additional environment variables can be set directly
+          LIBCLANG_PATH="${libclang.lib}/lib";
+        };
+
+        # Build *just* the cargo dependencies (of the entire workspace),
+        # so we can reuse all of that work (e.g. via cachix) when running in CI
+        cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+          pname = "zebrad-workspace-dependency-artifacts";
+          version = "0.0.0";
+        });
+
+        individualCrateArgs = (crate:
+          let
+            result = commonArgs // {
+              inherit cargoArtifacts;
+              inherit (traceJson (craneLib.crateNameFromCargoToml { cargoToml = traceJson (crate + "/Cargo.toml"); }))
+                pname
+                version
+              ;
+
+              # BUG 1: We should not need this on the assumption that crane already knows the package from pname?
+              # BUG 2: crate is a path, not a string.
+              # cargoExtraArgs = "-p ${crate}";
+            };
+          in
+            assert builtins.isPath crate;
+            traceJson result
+        );
+
+        # Build the top-level crates of the workspace as individual derivations.
+        # This allows consumers to only depend on (and build) only what they need.
+        # Though it is possible to build the entire workspace as a single derivation,
+        # so this is left up to you on how to organize things
+        #
+        # Note that the cargo workspace must define `workspace.members` using wildcards,
+        # otherwise, omitting a crate (like we do below) will result in errors since
+        # cargo won't be able to find the sources for all members.
+        zebrad = craneLib.buildPackage (individualCrateArgs ./zebrad);
+      in
+      {
+        checks = {
+          # Build the crates as part of `nix flake check` for convenience
+          inherit zebrad;
+
+          # Run clippy (and deny all warnings) on the workspace source,
+          # again, reusing the dependency artifacts from above.
+          #
+          # Note that this is done as a separate derivation so that
+          # we can block the CI if there are issues here, but not
+          # prevent downstream consumers from building our crate by itself.
+          my-workspace-clippy = craneLib.cargoClippy (commonArgs // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+
+          my-workspace-doc = craneLib.cargoDoc (commonArgs // {
+            inherit cargoArtifacts;
+          });
+
+          # Check formatting
+          my-workspace-fmt = craneLib.cargoFmt {
+            inherit src;
+          };
+
+          my-workspace-toml-fmt = craneLib.taploFmt {
+            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
+            # taplo arguments can be further customized below as needed
+            # taploExtraArgs = "--config ./taplo.toml";
+          };
+
+          # Audit dependencies
+          my-workspace-audit = craneLib.cargoAudit {
+            inherit src advisory-db;
+          };
+
+          # Audit licenses
+          my-workspace-deny = craneLib.cargoDeny {
+            inherit src;
+          };
+
+          # Run tests with cargo-nextest
+          # Consider setting `doCheck = false` on other crate derivations
+          # if you do not want the tests to run twice
+          my-workspace-nextest = craneLib.cargoNextest (commonArgs // {
+            inherit cargoArtifacts;
+            partitions = 1;
+            partitionType = "count";
+          });
+        };
+
+        packages = {
+          inherit zebrad;
+
+          default = zebrad;
+        };
+
+        apps = {
+          zebrad = flake-utils.lib.mkApp {
+            drv = zebrad;
+          };
+        };
+
+        devShells.default = (
+          let
+            mkClangShell = pkgs.mkShell.override {
+              inherit (pkgs.llvmPackages) stdenv;
+            };
+
+            devShellInputs = with pkgs; [
+              rustup
+            ];
+
+          in mkClangShell (commonArgs // {
+            # Include devShell inputs:
+            nativeBuildInputs = commonArgs.nativeBuildInputs ++ devShellInputs;
+          })
+        );
+      });
+}
+


### PR DESCRIPTION
## Motivation

This adds support for [nixos.org](https://nixos.org) development, builds, and CI/CD to support `nix` users. Anyone with the `nix` tool will be able to reproducibly build or enter a development shell via `nix build` or `nix develop` without any other system configurations or prerequisites.

This builds the zebra binaries and also renders the book.

### Specifications & References

- https://nixos.org

## Solution

Support is via three files:

- `flake.nix` is the `nix` configuration.
- `flake.lock` pins all dependencies (including platform dependencies) by hash.
- CI/CD support: There's a simple job to run `nix check` on a debian system. This builds and runs things like `cargo test`.

### Tests

`nix check` runs `cargo test` with the nixified build. This is the primary validation that the nix build works.

There's also a manual test, which is to start `nix develop` locally, then modify code/book contents and run the "natural" build commands like `cargo build` or `mdbook build` and verify they work. That happens daily on my platform.

### Follow-up Work

- See if we can improve CI caching?
- Should I just use the approach in https://github.com/ZcashFoundation/zebra/pull/9023#issuecomment-2632701738 ?

### PR Author's Checklist

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested via GitHub actions for both `nix build` and executing `cargo build && cargo test` within the `nix develop` shell.
- [ ] The `nix build` command runs all unit tests successfully.
- [ ] The documentation is updated so that `README.md` refers to the nix support.

### PR Reviewer's Checklist

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

