### PR TITLE
feat: add cargo clippy to CI

### DIFF
--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -22,7 +22,7 @@ env:
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }} # defaults to 0
 
 jobs:
-  test-no-run:
+  test:
     name: Crosslink Tests
     runs-on: ubuntu-latest-xl
     steps:
@@ -31,6 +31,10 @@ jobs:
         with:
           packages: protobuf-compiler
           version: 1.0
+      - name: Static Analysis
+        run: |
+          cargo fmt --check
+          cargo clippy --locked --workspace
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - name: Build Test Binary

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -31,10 +31,6 @@ jobs:
         with:
           packages: protobuf-compiler
           version: 1.0
-      - name: Static Analysis
-        run: |
-          cargo fmt --check
-          cargo clippy --locked --workspace
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - name: Build Test Binary
@@ -54,7 +50,10 @@ jobs:
           version: 1.0
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check
+      - name: Static Analysis
+        run: |
+          cargo fmt --check
+          cargo clippy --locked --workspace
       - name: Ensure Crosslink docs generate
         run: cd zebra-crosslink && cargo doc --lib
       - name: Ensure all docs generate

--- a/zebra-crosslink/src/lib.rs
+++ b/zebra-crosslink/src/lib.rs
@@ -1,5 +1,7 @@
 //! Internal Zebra service for managing the Crosslink consensus protocol
 
+#![allow(clippy::print_stdout)]
+
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -113,7 +115,7 @@ async fn block_height_hash_from_hash(
     }
 }
 
-async fn block_header_from_hash(
+async fn _block_header_from_hash(
     call: &TFLServiceCalls,
     hash: BlockHash,
 ) -> Option<Arc<BlockHeader>> {
@@ -126,7 +128,7 @@ async fn block_header_from_hash(
     }
 }
 
-async fn block_prev_hash_from_hash(call: &TFLServiceCalls, hash: BlockHash) -> Option<BlockHash> {
+async fn _block_prev_hash_from_hash(call: &TFLServiceCalls, hash: BlockHash) -> Option<BlockHash> {
     if let Ok(ReadStateResponse::BlockHeader { header, .. }) =
         (call.read_state)(ReadStateRequest::BlockHeader(hash.into())).await
     {
@@ -999,7 +1001,7 @@ async fn tfl_block_sequence(
     let mut c = 0;
     loop {
         if chunk_i >= chunk.len() {
-            let chunk_start_hash = if chunk.len() == 0 {
+            let chunk_start_hash = if !chunk.is_empty() {
                 &init_hash
             } else {
                 // NOTE: as the new first element, this won't be repeated
@@ -1013,7 +1015,7 @@ async fn tfl_block_sequence(
             .await;
 
             if let Ok(ReadStateResponse::BlockHashes(chunk_hashes)) = res {
-                if c == 0 && include_start_hash && chunk_hashes.len() > 0 {
+                if c == 0 && include_start_hash && !chunk_hashes.is_empty() {
                     assert_eq!(
                         chunk_hashes[0], start_hash,
                         "first hash is not the one requested"
@@ -1139,7 +1141,7 @@ fn tfl_dump_blocks(blocks: &[BlockHash], infos: &[Option<Arc<Block>>]) {
     }
 }
 
-async fn tfl_dump_block_sequence(
+async fn _tfl_dump_block_sequence(
     call: &TFLServiceCalls,
     start_hash: BlockHash,
     final_hash: Option<BlockHash>,

--- a/zebra-crosslink/src/service.rs
+++ b/zebra-crosslink/src/service.rs
@@ -120,7 +120,6 @@ pub(crate) type ReadStateServiceProcedure = Arc<
 /// - `read_state_service_call` takes a [`ReadStateRequest`] as input and returns a [`ReadStateResponse`] as output.
 ///
 /// [`TFLServiceHandle`] is a shallow handle that can be cloned and passed between threads.
-
 pub fn spawn_new_tfl_service(
     read_state_service_call: ReadStateServiceProcedure,
 ) -> (TFLServiceHandle, JoinHandle<Result<(), String>>) {

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1443,7 +1443,9 @@ where
             if let Ok(sink) = sink.accept().await {
                 // let stream = futures::stream::iter(["one", "two", "three"]);
                 // sink.pipe_from_stream(stream).await;
-                let _ = sink.send(jsonrpsee::SubscriptionMessage::from("RPC: hi".to_string()));
+                let _ = sink
+                    .send(jsonrpsee::SubscriptionMessage::from("RPC: hi".to_string()))
+                    .await;
                 // TODO: await/poll
                 this.stream_tfl_new_final_block_hash().await;
             }


### PR DESCRIPTION
This PR adds `cargo clippy` to CI and also fixes some clippy lints. Note that I did add `#![allow(clippy::print_stdout)]` ...for now.