### PR TITLE
fix(tests): missing fields on test structs

### DIFF
--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "ms*"]
 
 # Ensures that only one workflow task will run at a time. Previous builds, if
 # already in process, will get cancelled. Only the latest commit will be allowed

--- a/zebra-crosslink/src/lib.rs
+++ b/zebra-crosslink/src/lib.rs
@@ -2,11 +2,6 @@
 
 #![allow(clippy::print_stdout)]
 
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::broadcast;
-use tokio::time::Instant;
-use tracing::{error, info, warn};
 use crate::core::Round as BFTRound;
 use async_trait::async_trait;
 use malachitebft_app_channel::app::config as mconfig;
@@ -29,8 +24,13 @@ use rand::{Rng, SeedableRng};
 use sha3::Digest;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
 use sync::RawDecidedValue;
 use tempdir::TempDir;
+use tokio::sync::broadcast;
+use tokio::time::Instant;
+use tracing::{error, info, warn};
 
 pub mod service;
 pub mod config {

--- a/zebra-crosslink/src/service.rs
+++ b/zebra-crosslink/src/service.rs
@@ -184,6 +184,8 @@ mod tests {
     // Helper function to create a test TFLServiceHandle
     fn create_test_service() -> TFLServiceHandle {
         let internal = Arc::new(Mutex::new(TFLServiceInternal {
+            bft_block_strings: Vec::new(),
+            proposed_bft_string: None,
             latest_final_block: None,
             tfl_is_activated: false, // dup of Some/None(latest_final_block)?
             stakers: Vec::new(),
@@ -198,6 +200,7 @@ mod tests {
             call: TFLServiceCalls {
                 read_state: read_state_service,
             },
+            config: crate::config::Config::default(),
         }
     }
 

--- a/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/src/viz.rs
@@ -1387,3 +1387,17 @@ pub fn main(tokio_root_thread_handle: JoinHandle<()>) {
 
     // tokio_root_thread_handle.join();
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_window_conf() {
+        let config = window::Conf {
+            window_title: "Zcash blocks".to_owned(),
+            fullscreen: false,
+            ..Default::default()
+        };
+    }
+}


### PR DESCRIPTION
I noticed running `cargo test --workspace crosslink` was failing compilation so I added these in.

This PR also adds CI on `ms*` branches