### PR TITLE
`flake.nix`: add support for the visualizer in `nix develop`.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -261,9 +261,19 @@
               mdbook-mermaid
             ];
 
+            dynlibs = with pkgs; [
+              libGL
+              libxkbcommon
+              xorg.libX11
+              xorg.libxcb
+              xorg.libXi
+            ];
+
           in mkClangShell (commonArgs // {
             # Include devShell inputs:
             nativeBuildInputs = commonArgs.nativeBuildInputs ++ devShellInputs;
+
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath dynlibs;
           })
         );
       });


### PR DESCRIPTION
Todos:

- [ ] Tweak `nix build` binaries so that they successfully link to shared libs.
- [ ] Bonus: quiet the warning that's printed twice on every `nix build`.