### PR TITLE
Messy first draft of constructing `BftPayload` in TFL service.

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,8 @@
+[language-server.rust-analyzer.config]
+#check.command = "clippy"
+check.command = "check"
+check.workspace = false
+
+[language-server.rust-analyzer.config.imports]
+prefix = "crate"
+granularity = { group = "module", enforce = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8601,6 +8601,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "zebra-chain",
+ "zebra-crosslink-chain",
  "zebra-state",
  "zebra-test",
 ]
@@ -8961,6 +8962,7 @@ dependencies = [
  "zebra-chain",
  "zebra-consensus",
  "zebra-crosslink",
+ "zebra-crosslink-chain",
  "zebra-grpc",
  "zebra-network",
  "zebra-node-services",

--- a/zebra-crosslink-chain/src/params.rs
+++ b/zebra-crosslink-chain/src/params.rs
@@ -1,11 +1,13 @@
 //! Zcash Crosslink protocol parameter definitions and values
 
+use std::fmt::Debug;
+
 /// Zcash Crosslink protocol parameters
 ///
 /// This is provided as a trait so that downstream users can define or plug in their own alternative parameters.
 ///
 /// Ref: [Zcash Trailing Finality Layer §3.3.3 Parameters](https://electric-coin-company.github.io/tfl-book/design/crosslink/construction.html#parameters)
-pub trait ZcashCrosslinkParameters {
+pub trait ZcashCrosslinkParameters: Debug {
     /// The best-chain confirmation depth, `σ`
     ///
     /// At least this many PoW blocks must be atop the PoW block used to obtain a finalized view.
@@ -22,6 +24,7 @@ pub trait ZcashCrosslinkParameters {
 /// Crosslink parameters chosed for prototyping / testing
 ///
 /// <div class="warning">No verification has been done on the security or performance of these parameters.</div>
+#[derive(Debug)]
 pub struct PrototypeParameters;
 
 impl ZcashCrosslinkParameters for PrototypeParameters {

--- a/zebra-crosslink/Cargo.toml
+++ b/zebra-crosslink/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.45" }
+zebra-crosslink-chain = { path = "../zebra-crosslink-chain" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.45" }
 
 serde = { workspace = true, features = ["serde_derive"] }

--- a/zebra-crosslink/src/service.rs
+++ b/zebra-crosslink/src/service.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 
 use zebra_chain::block::{Hash as BlockHash, Height as BlockHeight};
 use zebra_chain::transaction::Hash as TxHash;
+use zebra_crosslink_chain::params::ZcashCrosslinkParameters;
 use zebra_state::{ReadRequest as ReadStateRequest, ReadResponse as ReadStateResponse};
 
 use crate::{
@@ -124,7 +125,7 @@ pub(crate) type ReadStateServiceProcedure = Arc<
 /// - `read_state_service_call` takes a [`ReadStateRequest`] as input and returns a [`ReadStateResponse`] as output.
 ///
 /// [`TFLServiceHandle`] is a shallow handle that can be cloned and passed between threads.
-pub fn spawn_new_tfl_service(
+pub fn spawn_new_tfl_service<ZCP: ZcashCrosslinkParameters>(
     read_state_service_call: ReadStateServiceProcedure,
     config: crate::config::Config,
 ) -> (TFLServiceHandle, JoinHandle<Result<(), String>>) {
@@ -146,7 +147,7 @@ pub fn spawn_new_tfl_service(
 
     (
         handle1,
-        tokio::spawn(async move { crate::tfl_service_main_loop(handle2).await }),
+        tokio::spawn(async move { crate::tfl_service_main_loop::<ZCP>(handle2).await }),
     )
 }
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -167,6 +167,7 @@ zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.4
 zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.45" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.45" }
 zebra-crosslink = { path = "../zebra-crosslink", version = "1.0.0-beta.45" }
+zebra-crosslink-chain = { path = "../zebra-crosslink-chain" }
 
 # Required for crates.io publishing, but it's only used in tests
 zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.45", optional = true }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -84,6 +84,7 @@ use tracing_futures::Instrument;
 
 use zebra_chain::block::genesis::regtest_genesis_block;
 use zebra_consensus::{router::BackgroundTaskHandles, ParameterCheckpoint};
+use zebra_crosslink_chain::params::PrototypeParameters;
 use zebra_rpc::server::RpcServer;
 
 #[cfg(feature = "getblocktemplate-rpcs")]
@@ -257,7 +258,7 @@ impl StartCmd {
         info!("spawning tfl service task");
         let (tfl, tfl_service_task_handle) = {
             let read_only_state_service = read_only_state_service.clone();
-            zebra_crosslink::service::spawn_new_tfl_service(
+            zebra_crosslink::service::spawn_new_tfl_service::<PrototypeParameters>(
                 Arc::new(move |req| {
                     let read_only_state_service = read_only_state_service.clone();
                     Box::pin(async move {


### PR DESCRIPTION
This is a half-complete integration of `BftPayload` into the BFT Proposal flow. It doesn't actually integrate it into BFT proposals, but constructs it then barfs with `todo!()`.

Much thanks to @azmr for teaching me the Zebra service APIs and other details to get this working.

Next steps are to integrate it into proposals, and separately ensure the validation and deserialization work for receiving proposals.

Even though this is messy and will cause a panic on main, I think it's good enough to either merge, or for @SamHSmith to rebase onto to continue his own work.