### PR TITLE
Add "Goto height"/"Track height" UIs

### DIFF
--- a/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/src/viz.rs
@@ -1855,12 +1855,12 @@ pub async fn viz_main(
             },
         );
 
-
         // UI CONTROLS ////////////////////////////////////////////////////////////
         let track_button_txt = "Track height";
         let goto_button_txt = "Goto height";
         let controls_txt_size = vec2(12. * ch_w, font_size);
-        let controls_wnd_size = controls_txt_size + vec2((track_button_txt.len() + 2) as f32 * ch_w, 1.2 * font_size);
+        let controls_wnd_size =
+            controls_txt_size + vec2((track_button_txt.len() + 2) as f32 * ch_w, 1.2 * font_size);
         ui_dynamic_window(
             hash!(),
             vec2(
@@ -1877,15 +1877,22 @@ pub async fn viz_main(
 
                 ui.same_line(controls_txt_size.x + ch_w);
 
-                if ui.button(None, if track_continuously {
-                    track_button_txt
-                } else {
-                    goto_button_txt
-                }) || enter_pressed {
-                    track_node_h = goto_str.trim().parse::<i32>().ok() ;
+                if ui.button(
+                    None,
+                    if track_continuously {
+                        track_button_txt
+                    } else {
+                        goto_button_txt
+                    },
+                ) || enter_pressed
+                {
+                    track_node_h = goto_str.trim().parse::<i32>().ok();
                 }
 
-                widgets::Checkbox::new(hash!()).label("Track Continuously").ratio(0.12).ui(ui, &mut track_continuously);
+                widgets::Checkbox::new(hash!())
+                    .label("Track Continuously")
+                    .ratio(0.12)
+                    .ui(ui, &mut track_continuously);
             },
         );
 
@@ -1894,12 +1901,12 @@ pub async fn viz_main(
             if let Some(node_i) = find_bc_node_i_by_height(&ctx.nodes, abs_h) {
                 let d_y: f32 = ctx.nodes[node_i].pt.y - ctx.fix_screen_o.y;
                 ctx.fix_screen_o.y += 0.4 * d_y;
-                if ! track_continuously && d_y.abs() < 1. {
+                if !track_continuously && d_y.abs() < 1. {
                     track_node_h = None;
                 }
-            } else if g.state.bc_tip.is_some() && abs_h.0 <= g.state.bc_tip.unwrap().0.0 {
+            } else if g.state.bc_tip.is_some() && abs_h.0 <= g.state.bc_tip.unwrap().0 .0 {
                 ctx.clear_nodes();
-                let hi = i32::try_from(abs_h.0 + VIZ_REQ_N/2).unwrap();
+                let hi = i32::try_from(abs_h.0 + VIZ_REQ_N / 2).unwrap();
                 new_h_rng = Some((sat_sub_2_sided(hi, VIZ_REQ_N), hi));
             } else {
                 println!("couldn't find node at {}", h);

--- a/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/src/viz.rs
@@ -1855,13 +1855,7 @@ pub async fn viz_main(
                 if ui.button(None, goto_button_txt) || enter_pressed {
                     if let Ok(abs_height) = goto_str.trim().parse::<u32>() {
                         track_node_ref = find_bc_node_i_by_height(&ctx.nodes, BlockHeight(abs_height));
-                        if let Some(node_i) = track_node_ref {
-                            // let node_screen_pt = world_camera.world_to_screen(ctx.nodes[node_i].pt);
-                            // println!("found node at {}: {} ({} => {})", abs_height, BlockHash(ctx.nodes[node_i].hash().expect("BC nodes should have a hash")),
-                            //     ctx.nodes[node_i].pt, node_screen_pt);
-                            ctx.fix_screen_o.y = ctx.nodes[node_i].pt.y;
-                            // TODO: smooth movement
-                        } else {
+                        if let None = track_node_ref {
                             println!("couldn't find node at {}", abs_height)
                         }
                     }
@@ -1870,12 +1864,13 @@ pub async fn viz_main(
             },
         );
 
-        // if let Some(node_i) = track_node_ref {
-        //     // TODO: this is awkward because vel & position are in different spaces
-        //     let mut d_y: f32 = ctx.screen_o.y - ctx.nodes[node_i].pt.y;
-        //     // d_y *= world_camera.zoom.y;
-        //     ctx.screen_vel.y += spring_force(d_y, ctx.screen_vel.y, /*m*/1., /*stiff*/0.1, /*damp*/0.1) / world_camera.zoom.y;
-        // }
+        if let Some(node_i) = track_node_ref {
+            let d_y: f32 = ctx.nodes[node_i].pt.y - ctx.fix_screen_o.y;
+            ctx.fix_screen_o.y += 0.4 * d_y;
+            if d_y.abs() < 1. {
+                track_node_ref = None;
+            }
+        }
 
         // HANDLE NODE SELECTION ////////////////////////////////////////////////////////////
         let hover_node_i: NodeRef = if mouse_is_over_ui {
@@ -2371,7 +2366,7 @@ pub async fn viz_main(
                 g.bc_req_h,
                 abs_block_heights(g.bc_req_h, g.state.bc_tip),
                 g.state.internal_proposed_bft_string,
-                track_node_ref.map(|i| ctx.nodes[i].pt),
+                track_node_ref.map(|i| (i, ctx.nodes[i].pt.y, (ctx.nodes[i].pt.y-ctx.screen_o.y).abs())),
             );
             draw_multiline_text(
                 &dbg_str,

--- a/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/src/viz.rs
@@ -1388,6 +1388,7 @@ pub async fn viz_main(
     let mut proposed_bft_string: Option<String> = None; // only for loop... TODO: rearrange
 
     let mut track_node_h: Option<i32> = None;
+    let mut track_continuously: bool = false;
     let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 
     let mut dbg = VizDbg {
@@ -1833,9 +1834,10 @@ pub async fn viz_main(
 
 
         // UI CONTROLS ////////////////////////////////////////////////////////////
+        let track_button_txt = "Track height";
         let goto_button_txt = "Goto height";
         let controls_txt_size = vec2(12. * ch_w, font_size);
-        let controls_wnd_size = controls_txt_size + vec2((goto_button_txt.len() + 2) as f32 * ch_w, 0.2 * font_size);
+        let controls_wnd_size = controls_txt_size + vec2((track_button_txt.len() + 2) as f32 * ch_w, 1.2 * font_size);
         ui_dynamic_window(
             hash!(),
             vec2(
@@ -1852,10 +1854,15 @@ pub async fn viz_main(
 
                 ui.same_line(controls_txt_size.x + ch_w);
 
-                if ui.button(None, goto_button_txt) || enter_pressed {
+                if ui.button(None, if track_continuously {
+                    track_button_txt
+                } else {
+                    goto_button_txt
+                }) || enter_pressed {
                     track_node_h = goto_str.trim().parse::<i32>().ok() ;
                 }
-                // TODO: "track height continuously" checkbox
+
+                widgets::Checkbox::new(hash!()).label("Track Continuously").ratio(0.12).ui(ui, &mut track_continuously);
             },
         );
 
@@ -1864,7 +1871,7 @@ pub async fn viz_main(
             if let Some(node_i) = find_bc_node_i_by_height(&ctx.nodes, abs_h) {
                 let d_y: f32 = ctx.nodes[node_i].pt.y - ctx.fix_screen_o.y;
                 ctx.fix_screen_o.y += 0.4 * d_y;
-                if d_y.abs() < 1. {
+                if ! track_continuously && d_y.abs() < 1. {
                     track_node_h = None;
                 }
             } else {

--- a/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/src/viz.rs
@@ -451,7 +451,7 @@ fn abs_block_height(height: i32, tip: Option<(BlockHeight, BlockHash)>) -> Block
     if height >= 0 {
         BlockHeight(height.try_into().unwrap())
     } else if let Some(tip) = tip {
-        tip.0.sat_sub(-height)
+        tip.0.sat_sub(!height)
     } else {
         BlockHeight(0)
     }

--- a/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/src/viz.rs
@@ -1376,6 +1376,7 @@ pub async fn viz_main(
     root_ui().push_skin(&skin);
 
     let (mut bc_h_lo_prev, mut bc_h_hi_prev) = (None, None);
+    let mut goto_str = String::new();
     let mut node_str = String::new();
     let mut target_bc_str = String::new();
     let mut bft_block_hi_i = 0;
@@ -1826,6 +1827,40 @@ pub async fn viz_main(
                 {
                     proposed_bft_string = Some(edit_proposed_bft_string.clone())
                 }
+            },
+        );
+
+
+        // UI CONTROLS ////////////////////////////////////////////////////////////
+        let goto_button_txt = "Goto height";
+        let controls_txt_size = vec2(12. * ch_w, font_size);
+        let controls_wnd_size = controls_txt_size + vec2((goto_button_txt.len() + 2) as f32 * ch_w, 0.2 * font_size);
+        ui_dynamic_window(
+            hash!(),
+            vec2(
+                window::screen_width() - (controls_wnd_size.x + 0.5 * font_size),
+                window::screen_height() - (controls_wnd_size.y + 0.5 * font_size),
+            ),
+            controls_wnd_size,
+            |ui| {
+                let enter_pressed = widgets::Editbox::new(hash!(), controls_txt_size)
+                    .multiline(false)
+                    .filter(&|ch| char::is_ascii_digit(&ch))// || ch == '-')
+                    .ui(ui, &mut goto_str)
+                    && (is_key_pressed(KeyCode::Enter) || is_key_pressed(KeyCode::KpEnter));
+
+                ui.same_line(controls_txt_size.x + ch_w);
+
+                if ui.button(None, goto_button_txt) || enter_pressed {
+                    if let Ok(abs_height) = goto_str.trim().parse::<u32>() {
+                        if let Some(node_i) = find_bc_node_i_by_height(&ctx.nodes, BlockHeight(abs_height)) {
+                            println!("found node at {}: {}", abs_height, BlockHash(ctx.nodes[node_i].hash().expect("BC nodes should have a hash")));
+                        } else {
+                            println!("couldn't find node at {}", abs_height);
+                        }
+                    }
+                }
+                // TODO: "track height continuously" checkbox
             },
         );
 


### PR DESCRIPTION
Add UI for jumping to & tracking different block heights.
Enables:
- more convenient navigation
- jumping to arbitrary heights
- camera-tracking the tip (or any other block)
- normal or tip-relative (negative) height references

### Follow-up Work

- Could add "jump to hash" if that's useful

### PR Checklist

- [X] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
- [X] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
