### PR TITLE
Fix `flake.nix` build/check in `ms3-upstream`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1743774569,
-        "narHash": "sha256-aYcphfeFQyUggtwNMye8dBkYALiMT6I/CSBCc+6H8Yk=",
+        "lastModified": 1755093932,
+        "narHash": "sha256-4nmZAK5KoxKKou1c67aYTL+/YMflwDNkGk0VsScGNGo=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "1701df31f7fee539165c51673a3956b13da41b3a",
+        "rev": "5c87b926136ad8b374e0025d5908f496d5249d43",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1743700120,
-        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "e316f19ee058e6db50075115783be57ac549c389",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1742452566,
-        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
+        "lastModified": 1755067290,
+        "narHash": "sha256-M5tvUutzwlbnSExaQKSKS/b/Cl6Kd0lEiLwt6mvD6t0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
+        "rev": "ef180474c4763fc19df569b5af259e2de32b9491",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743689281,
-        "narHash": "sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ+VoVdg=",
+        "lastModified": 1755082269,
+        "narHash": "sha256-Ix7ALeaxv9tW4uBKWeJnaKpYZtZiX4H4Q/MhEmj4XYA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2bfc080955153be0be56724be6fa5477b4eefabb",
+        "rev": "d74de548348c46cf25cb1fcc4b74f38103a4590d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,14 @@
         enableTrace = false;
         traceJson = if enableTrace then (lib.debug.traceValFn builtins.toJSON) else (x: x);
 
-        craneLib = crane.mkLib pkgs;
+        # Note: Yes, it's really this terrible. You would think nix would "just build" rust, but no...
+        craneLib =
+          let
+            fenixlib = fenix.packages."${system}";
+            rustToolchain = fenixlib.fromToolchainFile { file = ./rust-toolchain.toml; };
+            intermediateCraneLib = crane.mkLib pkgs;
+          in
+          intermediateCraneLib.overrideToolchain rustToolchain;
 
         # We use the latest nixpkgs `libclang`:
         inherit (pkgs.llvmPackages) libclang;

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
         craneLib =
           let
             fenixlib = fenix.packages."${system}";
-            rustToolchain = fenixlib.fromToolchainFile { file = ./rust-toolchain.toml; };
+            rustToolchain = fenixlib.stable.toolchain;
             intermediateCraneLib = crane.mkLib pkgs;
           in
           intermediateCraneLib.overrideToolchain rustToolchain;


### PR DESCRIPTION
The `ms3-upstream` branch fails to `nix build` because some new dependency requires `rust` 1.89.

This PR against that branch fixes `nix build` by using the `fenix` `stable` toolchain, which just happens to be 1.89.

At first I tried dynamically honoring `rust-toolchain.toml` but that is impure (i.e. not reproducible), so this configuration will only continue to work so long as all the crates don't require a newer stable. Once they do, then hopefully a `nix flake update --commit-lock-file` will resolve the issue. If not, we need to switch to a different strategy in `flake.nix`. 