### PR TITLE
CI QoL, Vol 1

### DIFF
--- a/.github/workflows/shieldedlabs-mdbook.yml
+++ b/.github/workflows/shieldedlabs-mdbook.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     env:
       MDBOOK_VERSION: 0.4.36
       MDBOOK_MERMAID_VERSION: 0.15.0

--- a/.github/workflows/shieldedlabs-mdbook.yml
+++ b/.github/workflows/shieldedlabs-mdbook.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       MDBOOK_VERSION: 0.4.36
       MDBOOK_MERMAID_VERSION: 0.15.0

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -42,13 +42,11 @@ jobs:
           sed -i -E 's/^([[:space:]]*network[[:space:]]*=[[:space:]]*)"Mainnet"/\1"Regtest"/' zebrad.toml
           mkdir -p ~/.config
           mv zebrad.toml ~/.config/zebrad.toml
-      - name: Build Test Binary
-        run: cargo test --locked --workspace --no-run --all-features
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Run Crosslink tests with nextest
-        run: |
-          cargo install cargo-binstall
-          cargo binstall cargo-nextest --force
-          cargo nextest run --locked --workspace --manifest-path=zebrad/Cargo.toml -- crosslink_
+        run: cargo nextest run --locked --workspace --manifest-path=zebrad/Cargo.toml -- crosslink_
 
   build:
     runs-on: blacksmith-8vcpu-ubuntu-2404

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   test:
     name: Crosslink Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
@@ -51,7 +51,7 @@ jobs:
           cargo nextest run --locked --workspace --manifest-path=zebrad/Cargo.toml -- crosslink_
 
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     name: Static Analysis and Docs
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
         run: cargo doc
 
   nix:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     name: Check Nix Flake
     permissions:
       actions: write

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -35,9 +35,9 @@ jobs:
           version: 1.0
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - run: cargo run generate > zebrad.toml
       - name: Configure Regtest network
         run: |
+          cargo run generate > zebrad.toml
           sed -i -E 's/^([[:space:]]*ephemeral[[:space:]]*=[[:space:]]*)false/\1true/' zebrad.toml
           sed -i -E 's/^([[:space:]]*network[[:space:]]*=[[:space:]]*)"Mainnet"/\1"Regtest"/' zebrad.toml
           mkdir -p ~/.config

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -1,6 +1,8 @@
 name: Crosslink Tests
 
 on:
+  push:
+    branches: ["main"]
   merge_group:
     types: [checks_requested]
   pull_request:

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -78,11 +78,8 @@ jobs:
         uses: nixbuild/nix-quick-install-action@v30
       - uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          purge: true
-          purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 86400 # 1 day
-          purge-primary-key: never
+          purge: false
       - name: nix flake check
         run: nix flake check

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -47,9 +47,6 @@ jobs:
           cargo install cargo-binstall
           cargo binstall cargo-nextest --force
           cargo nextest run --locked --workspace --manifest-path=zebrad/Cargo.toml -- crosslink_
-      - name: Regression tests # mostly
-        if: github.ref == 'refs/heads/main'
-        run: cargo test
 
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -69,28 +66,6 @@ jobs:
       - name: Ensure all docs generate
         if: github.ref == 'refs/heads/main'
         run: cargo doc
-
-  coverage:
-    runs-on: ubuntu-latest-xl
-    steps:
-      - uses: actions/checkout@v4
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: protobuf-compiler
-          version: 1.0
-      - run: rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
-      - name: Install cargo llvm-cov
-        run: cargo install cargo-llvm-cov
-      - name: Coverage
-        run: cargo llvm-cov --lcov --no-report --package zebra-crosslink
-      - name: Upload Coverage
-        run: cargo llvm-cov --html --no-run --ignore-filename-regex="zebra-(state|chain)"
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: target/llvm-cov/html
 
   nix:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Configure Regtest network
         run: |
-          cargo run generate > zebrad.toml
+          cargo run --bin zebrad generate > zebrad.toml
           sed -i -E 's/^([[:space:]]*ephemeral[[:space:]]*=[[:space:]]*)false/\1true/' zebrad.toml
           sed -i -E 's/^([[:space:]]*network[[:space:]]*=[[:space:]]*)"Mainnet"/\1"Regtest"/' zebrad.toml
           mkdir -p ~/.config

--- a/.github/workflows/shieldedlabs-tests.yml
+++ b/.github/workflows/shieldedlabs-tests.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   test:
     name: Crosslink Tests
-    runs-on: ubuntu-latest-xl
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
@@ -52,7 +52,7 @@ jobs:
         run: cargo test
 
   build:
-    runs-on: ubuntu-latest-xl
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Static Analysis and Docs
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
           path: target/llvm-cov/html
 
   nix:
-    runs-on: ubuntu-latest-xl
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Check Nix Flake
     permissions:
       actions: write


### PR DESCRIPTION
This PR:
1. Migrates the runners to blacksmith.sh
2. Removes coverage job and extra test step we werent really using anyway
3. Restores "Crosslink Tests" running on pushes to main.
4. Installs `cargo-nextest` directly instead of building it in the runner
5. Removes extraneous `cargo test` call
6. Turns off cache purging for `nix flake check`