### PR TITLE
Simplify the mdbook build script; does not copy book source to output.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -167,28 +167,7 @@
             mdbook
             mdbook-mermaid
           ];
-          builder = pkgs.writeShellScript "${name}-builder.sh" ''
-            source "$stdenv/setup"
-
-            set -x
-
-            cp -r "$src/" ./build
-            cd ./build/book
-
-            # Create the rendering output dir:
-            chmod u+w .
-            mkdir ./book
-            chmod u-w .
-
-            # Render:
-            mdbook build
-
-            # Copy to output:
-            mkdir -p "$out/book"
-            cp -r . "$out/book/"
-
-            set +x
-          '';
+          builder = pkgs.writeShellScript "${name}-builder.sh" ''mdbook build --dest-dir "$out/book/book" "$src/book"'';
         };
 
         zebra-all-pkgs = pkgs.symlinkJoin {


### PR DESCRIPTION
The mdbook nix build script can just be a single command.

Note: the base main branch version copies the full book source (e.g. `book.toml` and the `src/` md files) but this patch does not do that. I'm assuming we don't need those source files in our book rendering CI.