### PR TITLE
Include derivation sources in result; Super thorny nix cache-invalidation improvements.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -222,7 +222,7 @@
         storepath-to-derivation =
           src:
           let
-            inherit (builtins) head match;
+            inherit (builtins) baseNameOf head match;
             inherit (lib.strings) isStorePath;
 
             srcName = if isStorePath src then head (match "^[^-]+-(.*)$" src) else baseNameOf src;
@@ -233,7 +233,7 @@
 
             name = "ln-to-${srcName}";
 
-            builder = pkgs.writeScript "script-to-${name}" ''
+            builder = pkgs.writeShellScript "script-to-${name}" ''
               outsrc="$out/src"
               mkdir -p "$outsrc"
               ln -sv "$src" "$outsrc/${srcName}"


### PR DESCRIPTION
Cache-invalid improvements mean you can edit the book or the rust source, and then when you `nix build` it only builds the piece (at roughly that granularity) you edited.

This saves me about 1-2 minutes for book edits (for a ~20 second render).