### PR TITLE
Deduplicate README.md from book intro chapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,11 @@
 # `zebra-crosslink`
 
-<!--
-  Note: This is the top-level source repo `README.md` as well as
-  the front of the `zebra-crosslink` book.
-
-  All of the relative path links of the form [anchor text](relative/path)
-  are relative to the book source directory which is at `./book/src`
-  under the repo dir.
-
-  For example, the [Build and Usage](user/build-and-usage.md) page's source is at
-  `./book/src/user/build-and-usage.md`.
--->
-
 <!-- Mark to add banner and badges -->
 
 `zebra-crosslink` is [Shielded Labs](https://shieldedlabs.net)'s implementation of *Zcash
-Crosslink*, a hybrid PoW/PoS consensus protocol for [Zcash](https://z.cash/). Refer to the [Rationale, Scope, and Goals](design/scoping.md) to understand our effort.
+Crosslink*, a hybrid PoW/PoS consensus protocol for [Zcash](https://z.cash/).
 
-## Milestone 4a Workshop
-
-If you're here to participate in the Milestone 4a Workshop (either during or after the event), please see the [Milestone 4a Workshop](milestone-4a-workshop.md)
-
-## Prototype Codebase
-
-***Status:*** This codebase is an early prototype, and suitable for the adventurous or curious who
-want to explore rough experimental releases.
-
-This [`zebra-crosslink`](https://github.com/ShieldedLabs/zebra-crosslink) codebase is a fork of
-[`zebra`](https://github.com/ZcashFoundation/zebra).
- If you simply want a modern Zcash production-ready mainnet node, please use that upstream node.
-
-This book is entirely focused on this implementation of *Zcash Crosslink*. For general Zebra usage
-or development documentation, please refer to the official [Zebra Book](https://zebra.zfnd.org/),
-keeping in mind changes in this prototype (which we attempt to thoroughly document here). The
-
-<!--
-overarching design of *Zcash Crosslink* in this prototype is based off of the [Crosslink 2 hybrid
-construction for the Trailing Finality
-Layer](https://electric-coin-company.github.io/tfl-book/design/crosslink.html).
--->
-
-### Build and Usage
-
-To try out the software and join the testnet, see [Build and Usage](user/build-and-usage.md).
-
-### Design and Implementation
-
-See the [Design](design.md) and [Implementation](implementation.md) for an understanding of this software that we update throughout development.
-
-## Maintainers
-
-`zebra-crosslink` is maintained by [Shielded Labs](https://shieldedlabs.net), makers of fine Zcash software.
-
-## Contributing
-
-Our github issues are open for feedback. We will accept pull requests after the [prototyping phase
-is done](https://ShieldedLabs.net/roadmap).
+Please refer to [The `zebra-crosslink` Book](https://shieldedlabs.github.io/zebra-crosslink), or you can view all of its source text in the `./book/src` directory in this repository.
 
 ## License
 

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -1,1 +1,51 @@
-{{#include ../../README.md}}
+# `zebra-crosslink`
+
+`zebra-crosslink` is [Shielded Labs](https://shieldedlabs.net)'s implementation of *Zcash
+Crosslink*, a hybrid PoW/PoS consensus protocol for [Zcash](https://z.cash/). Refer to the [Rationale, Scope, and Goals](design/scoping.md) to understand our effort.
+
+## Milestone 4a Workshop
+
+If you're here to participate in the Milestone 4a Workshop (either during or after the event), please see the [Milestone 4a Workshop](milestone-4a-workshop.md)
+
+## Prototype Codebase
+
+***Status:*** This codebase is an early prototype, and suitable for the adventurous or curious who
+want to explore rough experimental releases.
+
+This [`zebra-crosslink`](https://github.com/ShieldedLabs/zebra-crosslink) codebase is a fork of
+[`zebra`](https://github.com/ZcashFoundation/zebra).
+ If you simply want a modern Zcash production-ready mainnet node, please use that upstream node.
+
+This book is entirely focused on this implementation of *Zcash Crosslink*. For general Zebra usage
+or development documentation, please refer to the official [Zebra Book](https://zebra.zfnd.org/),
+keeping in mind changes in this prototype (which we attempt to thoroughly document here). The
+
+overarching design of *Zcash Crosslink* in this prototype is based off of the [Crosslink 2 hybrid
+construction for the Trailing Finality
+Layer](https://electric-coin-company.github.io/tfl-book/design/crosslink.html).
+
+### Build and Usage
+
+To try out the software and join the testnet, see [Build and Usage](user/build-and-usage.md).
+
+### Design and Implementation
+
+See the [Design](design.md) and [Implementation](implementation.md) for an understanding of this software that we update throughout development.
+
+## Maintainers
+
+`zebra-crosslink` is maintained by [Shielded Labs](https://shieldedlabs.net), makers of fine Zcash software.
+
+## Contributing
+
+Our github issues are open for feedback. We will accept pull requests after the [prototyping phase
+is done](https://ShieldedLabs.net/roadmap).
+
+## License
+
+Zebra is distributed under the terms of both the MIT license and the Apache
+License (Version 2.0). Some Zebra crates are distributed under the [MIT license
+only](LICENSE-MIT), because some of their code was originally from MIT-licensed
+projects. See each crate's directory for details.
+
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT).

--- a/book/src/milestone-4a-workshop.md
+++ b/book/src/milestone-4a-workshop.md
@@ -5,7 +5,7 @@ Welcome to the Milestone 4 Workshops / Demo guide!
 To join the Milestone 4a demo network follow these steps:
 
 1. Join the Zoom link, which is/will be posted [in the Milestone 4a Forum Thread](https://forum.zcashcommunity.com/t/crosslink-workshop-wednesday-oct-22nd-at-5pm-utc/52505).
-2. Download a [`zebra-crosslink` prebuilt binary](https://github.com/ShieldedLabs/zebra-crosslink/releases/latest) for your architecture.
+2. Download a [`zebra-crosslink` prebuilt binary](https://github.com/ShieldedLabs/zebra-crosslink/releases) for your architecture.
   - They are named as `zebra-crosslink-viz-<architecture>` for a binary with the integrated interactive visualizer gui, which we recommend.
   - If the visualizer doesn't run on your system or you prefer a console only node, use the `zebra-crosslink-<architecture>` binary (without the `-viz` infix).
 3. Configure the downloaded binary for your operating system.


### PR DESCRIPTION
Prior to this PR the toplevel `README.md` _is_ also the book intro page. This is confusing especially with respect to links, because there are different view contexts (github render, mdbook render, local editor view, ...).

This creates a new distinct `README.md` at the top-level that is barebones and links to the book render and/or src.

Also, this changes the link for releases by dropping the `/latest/` suffix from the URL, which is part of simplifying the "releases funnel" so that no matter how people arrive there, they see the correct relevant thing: most recent `zebra-crosslink` prototype builds.