### PR TITLE
Streamline book content and introduce a barebones `Terminology` stub chapter.

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,9 +1,9 @@
 [book]
-authors = ["Zcash Foundation <zebra@zfnd.org>"]
+authors = ["Shielded Labs <https://shieldedlabs.net>"]
 language = "en"
 multilingual = false
 src = "src"
-title = "The Zebra Book"
+title = "The Zebra Crosslink Book"
 
 [preprocessor]
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,7 +1,6 @@
 # Summary
 
-[`README.md`](README.md)
-
+[Overview](overview.md)
 - [Milestone 4a Workshop](milestone-4a-workshop.md)
 - [User Documentation](user.md)
   - [Build and Usage](user/build-and-usage.md)
@@ -9,5 +8,6 @@
 - [Design](design.md)
   - [Rationale, Scope, and Goals](design/scoping.md)
     - [Deliverable Goals](design/deliverables.md)
+  - [Terminology](design/terminology.md)
   - [Architectural Decision Records](design/adrs.md)
 - [Implementation](implementation.md)

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -1,24 +1,19 @@
 # Crosslink Design
 
-As we proceed we intend to produce design documentation that is abstracted from implementation, but more comprehensive than the [TFL Book](https://electric-coin-company.github.io/tfl-book/) design because it encompasses all of a specific concrete integrated hybrid protocol with full PoW, BFT, and PoS scope.
+The `zebra-crosslink` design fleshes out and adapts the abstract [Crosslink 2](https://electric-coin-company.github.io/tfl-book/design/crosslink.html) into a working implementation. This includes extending and adapting that construction to include a fully functional BFT protocol, and including staking mechanics, accounting, and associated security reasoning and arguments. Additionally, we explicitly alter some trade-offs, or terminology compared to the abstract construction.
 
-- The keystone document for this is an in-progress [ZIP Draft](https://docs.google.com/document/d/1wSLLReAEe4cM60VMKj0-ze_EHS12DqVoI0QVW8H3X9E/edit?tab=t.0#heading=h.f0ehy0pxr01t) which will enter the formal [ZIP](https://zips.z.cash) process as it matures.
-- Additionally, we are tracking _Architecture Design Rationales_ as we prototype the complete design. More detail is provided in the [Implementation Approach](#implementation-approach) section below.
+This Design chapter focuses specifically on differences from pure PoW Zcash (using [`zebra`](https://zebra.zfnd.org/) as a reference implementation) and the Crosslink 2 construction. We assume basic familiarity with both. Also, please see our [Terminology](terminology.md) for terms specific to this project.
 
-## Design Adherence, Safety, & Analysis
+We will be refining a [ZIP Draft](https://docs.google.com/document/d/1wSLLReAEe4cM60VMKj0-ze_EHS12DqVoI0QVW8H3X9E/edit?tab=t.0#heading=h.f0ehy0pxr01t) which will enter the formal [ZIP](https://zips.z.cash) process as the prototype approaches maturity and we switch focus to productionization.
 
-Note the scope of these decisions may deviate from the more rigorous yet abstract [TFL Book §3.3 The Crosslink Construction](https://electric-coin-company.github.io/tfl-book/design/crosslink.html)!
+## _WARNINGS_
 
-This means the prototype _may_ violate some of the security assumptions or other goals of that design, so we make no assurances _the prototype is not safe_. We have three possible types of rationale for these deviations:
+- These extensions and changes from the [Crosslink 2](https://electric-coin-company.github.io/tfl-book/design/crosslink.html) construction may violate some of the assumptions in the ssecurity proofs. This still needs to be reviewed after this design is more complete.
+- We are using a custom-fit in-house BFT protocol for prototyping. It's own security properties need to be more thoroughly verified.
+- All trade-off decisions need to be thoroughly vetted for market fit, while ensuring we maintain a minimum high bar for safety befitting Zcash's pedigree. Part of our implementation approach is to do rapid prototyping to explore the market fit more directly while modifying trade-offs in the design.
+
+It is especially important that we identify deviations from Zcash PoW consensus, the [Crosslink 2](https://electric-coin-company.github.io/tfl-book/design/crosslink.html) construction, and the upstream [`zebra`](https://zebra.zfnd.org/) implementation. In particular, it is important for us to clarify our rationale for deviation, which may fit one of these general categories:
 
 - We _intentionally_ prefer a different trade-off to the original design; in which case we should have very explicit rationale documentation about the difference (in an ADR). One example (**TODO**: not-yet-done) is our ADR-0001 selects a different approach to on-chain signatures than (**TODO**: link to TFL section).
 - Something about the more abstract design makes assumptions we cannot uphold in practice with all of the other implementation constraints. In this case, we need to determine if the upstream design needs to be improved, or we need to alter our implementation constraints.
-- As an expedient, we found it quicker and easier to do something different to get the prototype working, even though we believe the design makes better trade-offs. These are prime candidates for improvement during productionization to match the design, or else require persuasive rationale that a "short cut" is worth the trade-offs and risks.
-
-## Architecture Design Rationales
-
-We use an approach of documenting many design decisions via "Architecture Design Rationale" documents, inspired by the upstream development process. These are especially important for our Prototype-then-Productionize approach, since they record key decisions we should review for production readiness.
-
-Currently ADRs are very rough and tracked on this [zebra-crosslink ADR Google Sheet](https://docs.google.com/spreadsheets/d/1X6dMxrkbWshhy8JwR7WkNC7JuN1J5YKNFzTcR-BolRo/edit?gid=0#gid=0).
-
-Moving forward we will begin to incorporate them into this codebase.
+- As an expedient, we found it quicker and easier to do something different to get the prototype working, even though we believe the upstream makes better trade-offs. These are prime candidates for improvement during productionization to match the design, or else require persuasive rationale that a "short cut" is worth the trade-offs and risks.

--- a/book/src/design/terminology.md
+++ b/book/src/design/terminology.md
@@ -1,0 +1,12 @@
+# Terminology
+
+Here we introduce terminology specific to this design, especially when it may deviate from other consensus systems or common terminology used in the consensus protocol field.
+
+## Finality
+
+We use the term _finality_ explicitly to mean an [objectively verifiable](#FIXME) property of a given local node's [block](#FIXME) which has these characteristics:
+
+- It is _accountable_ because the chain contains explicit voting records which indicate each participating [finalizer](#FIXME)'s on-chain behavior.
+- It is _irreversible_ within the protocol scope. The only way to "undo" a final block is to modify the software to do so, which requires intervention by the user. Note that because a [finality safety violation](#FIXME) is always theoretically possible, this implies the only recovery from such a violation is out-of-band to the protocol and requires human intervention.
+- It is _in consensus_ meaning that all nodes which have received a sufficient number of valid blocks agree on the finality status, and also can rely on all other nodes in this set arriving at the same conclusion.
+- It provides [assymetric cost-of-attack defense](#FIXME).

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -1,11 +1,11 @@
-# `zebra-crosslink`
+# The `zebra-crosslink` Book
 
 `zebra-crosslink` is [Shielded Labs](https://shieldedlabs.net)'s implementation of *Zcash
-Crosslink*, a hybrid PoW/PoS consensus protocol for [Zcash](https://z.cash/). Refer to the [Rationale, Scope, and Goals](design/scoping.md) to understand our effort.
+Crosslink*, a hybrid PoW/PoS consensus protocol for [Zcash](https://z.cash/). Refer to the [Rationale, Scope, and Goals](design/scoping.md) to understand our effort. See [our roadmap](https://shieldedlabs.net/roadmap/) for current progress status.
 
 ## Milestone 4a Workshop
 
-If you're here to participate in the Milestone 4a Workshop (either during or after the event), please see the [Milestone 4a Workshop](milestone-4a-workshop.md)
+If you're here to participate in the Milestone 4a Workshop (either during or after the event), please see the [Milestone 4a Workshop](milestone-4a-workshop.md).
 
 ## Prototype Codebase
 
@@ -16,21 +16,13 @@ This [`zebra-crosslink`](https://github.com/ShieldedLabs/zebra-crosslink) codeba
 [`zebra`](https://github.com/ZcashFoundation/zebra).
  If you simply want a modern Zcash production-ready mainnet node, please use that upstream node.
 
-This book is entirely focused on this implementation of *Zcash Crosslink*. For general Zebra usage
-or development documentation, please refer to the official [Zebra Book](https://zebra.zfnd.org/),
-keeping in mind changes in this prototype (which we attempt to thoroughly document here). The
-
-overarching design of *Zcash Crosslink* in this prototype is based off of the [Crosslink 2 hybrid
-construction for the Trailing Finality
-Layer](https://electric-coin-company.github.io/tfl-book/design/crosslink.html).
-
 ### Build and Usage
 
 To try out the software and join the testnet, see [Build and Usage](user/build-and-usage.md).
 
 ### Design and Implementation
 
-See the [Design](design.md) and [Implementation](implementation.md) for an understanding of this software that we update throughout development.
+This book is entirely focused on this implementation of *Zcash Crosslink*. For general Zebra usage or development documentation, please refer to the official [Zebra Book](https://zebra.zfnd.org/). We strive to document the [Design](design.md) and [Implementation](implementation.md) changes in this book.
 
 ## Maintainers
 


### PR DESCRIPTION
This branch also rust formatting failures inherited from `main`, so if those fixes land on main they should resolve here (with a rebase at least).
